### PR TITLE
version 0.7.2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
         "--disable=W0511",
         "--disable=W0012",
         "--extension-pkg-whitelist=RPi",
-    ]
+    ],
+    "files.trimTrailingWhitespace": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## version 0.7.2
+
+- moved StallGuard code into own mixin class
+- fixed StallGuard on TMC2240 (diag0_pushpull and diag0_stall needed to be activated)
+- renamed sgresult and sgthrs reg values in order to have them consistend between drivers
+
 ## version 0.7
 
 - added Support for TMC2240

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The Documentation of the TMC2209 can be found here:
 
 The code is also available on [PyPI](https://pypi.org/project/PyTmcStepper).
 
-## Installation
+## Installation (on Raspberry Pi)
 
 ### Installation with PIP
 
@@ -95,16 +95,16 @@ is split into their own classes to be able to support the diverse methods.
 
 EnableControl   | Class                 | Driver    | Notes
 --              | --                    | --        | --
-Pin             | TmcEnableControlPin   | all       | the EN Pin of the Driver needs to be connected to a GPIO of the Pi
-TOff            | TmcEnableControlToff  | all       | the EN Pin needs to be connected to GND.<br />On the TMC2209 this enables current Output on Startup!<br />On the TMC2240 this works fine, because TOff is per default 0 (off).
+Pin             | [TmcEnableControlPin](src/tmc_driver/enable_control/_tmc_ec_pin.py)   | all       | the EN Pin of the Driver needs to be connected to a GPIO of the Pi
+TOff            | [TmcEnableControlToff](src/tmc_driver/enable_control/_tmc_ec_toff.py)  | all       | the EN Pin needs to be connected to GND.<br />On the TMC2209 this enables current Output on Startup!<br />On the TMC2240 this works fine, because TOff is per default 0 (off).
 
 ### MotionControl
 
 MotionControl   | Class                     | Driver    | Notes
 --              | --                        | --        | --
-STEP/DIR        | TmcMotionControlStepDir   | all       | the STEP and DIR pin of the driver must each be connected to a GPIO of the Pi
-STEP/REG        | TmcMotionControlStepReg   | all       | only the STEP pin needs to be connected to a GPIO of the Pi.<br />The direction is controlled via the Register.
-VACTUAL         | TmcMotionControlVActual   | TMC220x   | the Direction and Speed is controlled via Register. But VActual does only allow setting a speed and therefore cannot control positioning of the Motor.
+STEP/DIR        | [TmcMotionControlStepDir](src/tmc_driver/motion_control/_tmc_mc_step_dir.py)  | all       | the STEP and DIR pin of the driver must each be connected to a GPIO of the Pi
+STEP/REG        | [TmcMotionControlStepReg](src/tmc_driver/motion_control/_tmc_mc_step_reg.py)   | all       | only the STEP pin needs to be connected to a GPIO of the Pi.<br />The direction is controlled via the Register.
+VACTUAL         | [TmcMotionControlVActual](src/tmc_driver/motion_control/_tmc_mc_vactual.py)  | TMC220x   | the Direction and Speed is controlled via Register. But VActual does only allow setting a speed and therefore cannot control positioning of the Motor.
 
 Further methods of controlling a motor could be:
 
@@ -116,8 +116,8 @@ Further methods of controlling a motor could be:
 
 Com     | Class         | Driver    | Notes
 --      | --            | --        | --
-UART    | TmcComUart    | all       | Communication via UART (RX, TX). See [Wiring](#uart)<br />[pyserial](https://pypi.org/project/pyserial) needs to be installed
-SPI     | TmcComSpi     | TMC2240   | Communication via SPI (MOSI, MISO, CLK, CS). See [Wiring](#spi)<br />[spidev](https://pypi.org/project/spidev) needs to be installed
+UART    | [TmcComUart](src/tmc_driver/com/_tmc_com_uart.py)    | all       | Communication via UART (RX, TX). See [Wiring](#uart)<br />[pyserial](https://pypi.org/project/pyserial) needs to be installed
+SPI     | [TmcComSpi](src/tmc_driver/com/_tmc_com_spi.py)     | TMC2240   | Communication via SPI (MOSI, MISO, CLK, CS). See [Wiring](#spi)<br />[spidev](https://pypi.org/project/spidev) needs to be installed
 
 ## Wiring
 
@@ -179,23 +179,25 @@ if not, check the connection of the pin.
 
 ### [demo_script_03_basic_movement.py](demo/demo_script_03_basic_movement.py)
 
-This script should move the motor 6 times, one revolution back and forth.
+This script shows the different functions available to move the motors.
+The motor is moved 4 times one revolution back and forth.
 
 ### [demo_script_04_stallguard.py](demo/demo_script_04_stallguard.py)
 
-In this script the stallguard feature of the TMC2209 is beeing setup.
+In this script the stallguard feature of the TMC2209 is being setup.
 A funtion will be called, if the driver detects a stall. The function stops the current movement.
 The motor will be moved 10 revolutions. If the movement is finished unhindered, the script outputs ```Movement finished successfully```.
 If you block the motor with pliers or something similar, the the motor will stop and the script outputs ```StallGuard!``` and ```Movement was not completed```
 
 ### [demo_script_05_vactual.py](demo/demo_script_05_vactual.py)
 
-VACTUAL allows moving the motor by UART control. It gives the motor velocity in +-(2^23)-1 [μsteps / t]
+VACTUAL enables the motor to be moved via the COM interface (UART) without additional GPIOs. The motor speed is transmitted as a value in +-(2^23)-1 [µsteps / t] via the COM interface.
 
 ### [demo_script_06_multiple_drivers.py](demo/demo_script_06_multiple_drivers.py)
 
 Multiple drivers can be addressed via UART by setting different addresses with the MS1 and MS2 pins.
 Simultaneous movement of multiple motors can be done with threaded movement.
+When using SPI different Drivers are accessed via the Chip Select pin.
 
 ### [demo_script_07_threads.py](demo/demo_script_07_threads.py)
 

--- a/demo/demo_script_04_stallguard.py
+++ b/demo/demo_script_04_stallguard.py
@@ -118,18 +118,17 @@ tmc.test_stallguard_threshold(800)
 def my_callback():
     """StallGuard callback"""
     print("StallGuard!")
-    tmc.stop()
+    tmc.tmc_mc.stop()
 
 tmc.set_stallguard_callback(26, 50, my_callback) # after this function call, StallGuard is active
 
 
 #uses STEP/DIR to move the motor
-finishedsuccessfully = tmc.run_to_position_steps(4000, MovementAbsRel.RELATIVE)
+result = tmc.run_to_position_steps(4000, MovementAbsRel.RELATIVE)
 #uses VActual Register to  move the motor
-# finishedsuccessfully = tmc.set_vactual_rpm(30, revolutions=10)
+# result = tmc.set_vactual_rpm(30, revolutions=10)
 
-
-if finishedsuccessfully is True:
+if result is StopMode.NO:
     print("Movement finished successfully")
 else:
     print("Movement was not completed")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = PyTmcStepper
-version = 0.7.1
+version = 0.7.2
 author = Christian Köhlke
 author_email = christian@koehlke.de
 description = This is a Python libary to drive a stepper motor with a Trinamic stepper driver and a single board computer like a Raspberry Pi

--- a/src/tmc_driver/_tmc_stallguard.py
+++ b/src/tmc_driver/_tmc_stallguard.py
@@ -1,0 +1,139 @@
+#pylint: disable=too-many-arguments
+#pylint: disable=too-many-public-methods
+#pylint: disable=too-many-branches
+#pylint: disable=too-many-instance-attributes
+#pylint: disable=too-many-positional-arguments
+#pylint: disable=bare-except
+#pylint: disable=no-member
+#pylint: disable=unused-import
+#pylint: disable=wildcard-import
+#pylint: disable=unused-wildcard-import
+"""StallGuard mixin
+"""
+
+import types
+from ._tmc_stepperdriver import *
+from .com._tmc_com import TmcCom
+from ._tmc_gpio_board import GpioPUD, GpioMode
+from ._tmc_logger import Loglevel
+from .reg._tmc224x_reg import *
+from . import _tmc_math as tmc_math
+
+
+
+
+
+class StallGuard():
+    """StallGuard
+
+    This class is used to control the stallguard feature of the TMC stepper driver.
+    The drivers class needs to inherit from this class to use the stallguard feature (mixin).
+    """
+    tmc_com:TmcCom = None
+
+    _pin_stallguard:int = None
+    _sg_callback:types.FunctionType = None
+
+
+
+    def set_stallguard_callback(self, pin_stallguard, threshold, callback,
+                                min_speed = 100):
+        """set a function to call back, when the driver detects a stall
+        via stallguard
+        high value on the diag pin can also mean a driver error
+
+        Args:
+            pin_stallguard (int): pin needs to be connected to DIAG
+            threshold (int): value for SGTHRS
+            callback (func): will be called on StallGuard trigger
+            min_speed (int): min speed [steps/s] for StallGuard (Default value = 100)
+        """
+        self.tmc_logger.log(f"setup stallguard callback on GPIO {pin_stallguard}", Loglevel.INFO)
+        self.tmc_logger.log(f"StallGuard Threshold: {threshold} | minimum Speed: {min_speed}", Loglevel.INFO)
+
+        self._set_stallguard_threshold(threshold)
+        self._set_coolstep_threshold(tmc_math.steps_to_tstep(min_speed, self.get_microstepping_resolution()))
+        self._sg_callback = callback
+        self._pin_stallguard = pin_stallguard
+
+        tmc_gpio.gpio_setup(self._pin_stallguard, GpioMode.IN, pull_up_down=GpioPUD.PUD_DOWN)
+        # first remove existing events
+        tmc_gpio.gpio_remove_event_detect(self._pin_stallguard)
+        tmc_gpio.gpio_add_event_detect(self._pin_stallguard, self.stallguard_callback)
+
+
+
+    def stallguard_callback(self, gpio_pin):
+        """the callback function for StallGuard.
+        only checks whether the duration of the current movement is longer than
+        _sg_delay and then calls the actual callback
+
+        Args:
+            gpio_pin (int): pin number of the interrupt pin
+        """
+        del gpio_pin
+        if self._sg_callback is None:
+            self.tmc_logger.log("StallGuard callback is None", Loglevel.DEBUG)
+            return
+        self._sg_callback()
+
+
+
+    def enable_coolstep(self, semin_sg:int = 150, semax_sg:int = 200, seup:int = 1, sedn:int = 3, min_speed:int = 100):
+        """enables coolstep and sets the parameters for coolstep
+        The values for semin etc. can be tested with the test_stallguard_threshold function
+
+        Args:
+            semin_sg (int): lower threshold. Current will be increased if SG_Result goes below this
+            semax_sg (int): upper threshold. Current will be decreased if SG_Result goes above this
+            seup (int): current increment step
+            sedn (int): number of SG_Result readings for each current decrement
+        """
+        semax_sg = semax_sg - semin_sg
+
+        self.coolconf.read()
+        self.coolconf.semin = round(max(0, min(semin_sg/32, 15)))
+        self.coolconf.semax = round(max(0, min(semax_sg/32, 15)))
+        self.coolconf.seimin = 1        # scale down to until 1/4 of IRun (7 - 31)
+        self.coolconf.seup = seup
+        self.coolconf.sedn = sedn
+        self.coolconf.write_check()
+
+        self._set_coolstep_threshold(tmc_math.steps_to_tstep(min_speed, self.get_microstepping_resolution()))
+
+
+
+    def get_stallguard_result(self):
+        """return the current stallguard result
+        its will be calculated with every fullstep
+        higher values means a lower motor load
+
+        Returns:
+            sgresult (int): StallGuard Result
+        """
+        self.sgresult.read()
+        return self.sgresult.sgresult
+
+
+
+    def _set_stallguard_threshold(self, threshold):
+        """sets the register bit "SGTHRS" to to a given value
+        this is needed for the stallguard interrupt callback
+        SGRESULT becomes compared to the double of this threshold.
+        SGRESULT ≤ SGTHRS*2
+
+        Args:
+            threshold (int): value for SGTHRS
+        """
+        self.sgthrs.modify("sgthrs", threshold)
+
+
+
+    def _set_coolstep_threshold(self, threshold):
+        """This  is  the  lower  threshold  velocity  for  switching
+        on  smart energy CoolStep and StallGuard to DIAG output. (unsigned)
+
+        Args:
+            threshold (int): threshold velocity for coolstep
+        """
+        self.tcoolthrs.modify("tcoolthrs", threshold)

--- a/src/tmc_driver/_tmc_stepperdriver.py
+++ b/src/tmc_driver/_tmc_stepperdriver.py
@@ -253,20 +253,22 @@ class TmcStepperDriver:
             self.tmc_mc.acceleration_fullstep = acceleration_fullstep
 
 
-    def run_to_position_steps(self, steps, movement_abs_rel:MovementAbsRel = None):
+    def run_to_position_steps(self, steps, movement_abs_rel:MovementAbsRel = None) -> StopMode:
         """motioncontrol wrapper"""
         if self.tmc_mc is not None:
-            self.tmc_mc.run_to_position_steps(steps, movement_abs_rel)
+            return self.tmc_mc.run_to_position_steps(steps, movement_abs_rel)
+        else:
+            return None
 
 
-    def run_to_position_fullsteps(self, steps, movement_abs_rel:MovementAbsRel = None):
+    def run_to_position_fullsteps(self, steps, movement_abs_rel:MovementAbsRel = None) -> StopMode:
         """motioncontrol wrapper"""
-        self.run_to_position_steps(steps * self.mres, movement_abs_rel)
+        return self.run_to_position_steps(steps * self.mres, movement_abs_rel)
 
 
-    def run_to_position_revolutions(self, revs, movement_abs_rel:MovementAbsRel = None):
+    def run_to_position_revolutions(self, revs, movement_abs_rel:MovementAbsRel = None) -> StopMode:
         """motioncontrol wrapper"""
-        self.run_to_position_steps(revs * self.steps_per_rev, movement_abs_rel)
+        return self.run_to_position_steps(revs * self.steps_per_rev, movement_abs_rel)
 
 
 # StepperDriver methods

--- a/src/tmc_driver/_tmc_stepperdriver.py
+++ b/src/tmc_driver/_tmc_stepperdriver.py
@@ -257,8 +257,7 @@ class TmcStepperDriver:
         """motioncontrol wrapper"""
         if self.tmc_mc is not None:
             return self.tmc_mc.run_to_position_steps(steps, movement_abs_rel)
-        else:
-            return None
+        return None
 
 
     def run_to_position_fullsteps(self, steps, movement_abs_rel:MovementAbsRel = None) -> StopMode:

--- a/src/tmc_driver/motion_control/_tmc_mc_step_dir.py
+++ b/src/tmc_driver/motion_control/_tmc_mc_step_dir.py
@@ -164,7 +164,7 @@ class TmcMotionControlStepDir(TmcMotionControl):
         tmc_gpio.gpio_output(self._pin_dir, direction.value)
 
 
-    def run_to_position_steps(self, steps, movement_abs_rel:MovementAbsRel = None):
+    def run_to_position_steps(self, steps, movement_abs_rel:MovementAbsRel = None) -> StopMode:
         """runs the motor to the given position.
         with acceleration and deceleration
         blocks the code until finished or stopped from a different thread!
@@ -203,7 +203,7 @@ class TmcMotionControlStepDir(TmcMotionControl):
         return self._stop
 
 
-    def run_to_position_revolutions(self, revolutions, movement_abs_rel:MovementAbsRel = None):
+    def run_to_position_revolutions(self, revolutions, movement_abs_rel:MovementAbsRel = None) -> StopMode:
         """runs the motor to the given position.
         with acceleration and deceleration
         blocks the code until finished!

--- a/src/tmc_driver/motion_control/_tmc_mc_vactual.py
+++ b/src/tmc_driver/motion_control/_tmc_mc_vactual.py
@@ -72,7 +72,7 @@ class TmcMotionControlVActual(TmcMotionControl):
 
 
     def set_vactual_dur(self, vactual, duration=0, acceleration=0,
-                             show_stallguard_result=False, show_tstep=False):
+                             show_stallguard_result=False, show_tstep=False) -> StopMode:
         """sets the register bit "VACTUAL" to to a given value
         VACTUAL allows moving the motor by UART control.
         It gives the motor velocity in +-(2^23)-1 [μsteps / t]
@@ -140,7 +140,7 @@ class TmcMotionControlVActual(TmcMotionControl):
         return self._stop
 
 
-    def set_vactual_rps(self, rps, duration=0, revolutions=0, acceleration=0):
+    def set_vactual_rps(self, rps, duration=0, revolutions=0, acceleration=0) -> StopMode:
         """converts the rps parameter to a vactual value which represents
         rotation speed in revolutions per second
         With internal oscillator:
@@ -163,7 +163,7 @@ class TmcMotionControlVActual(TmcMotionControl):
         return self.set_vactual_dur(vactual, duration, acceleration=acceleration)
 
 
-    def set_vactual_rpm(self, rpm, duration=0, revolutions=0, acceleration=0):
+    def set_vactual_rpm(self, rpm, duration=0, revolutions=0, acceleration=0) -> StopMode:
         """converts the rps parameter to a vactual value which represents
         rotation speed in revolutions per minute
 

--- a/src/tmc_driver/reg/_tmc224x_reg.py
+++ b/src/tmc_driver/reg/_tmc224x_reg.py
@@ -294,7 +294,7 @@ class DrvStatus(TmcReg):
             ["stealth",             14, 0x1,    bool,   None, ""],
             ["s2vsb",               13, 0x1,    bool,   None, ""],
             ["s2vsa",               12, 0x1,    bool,   None, ""],
-            ["sg_result",           0,  0x3FF,  int,    None, ""]
+            ["sgresult",            0,  0x3FF,  int,    None, ""]
         ]
         super().__init__(0x6F, "DRVSTATUS", tmc_com, reg_map)
 
@@ -320,9 +320,9 @@ class SgThrs(TmcReg):
         reg_map = [
             ["sg_angle_offset",      9,  0x1,   bool,   None, ""],
             ["sg4_filt_en",          8,  0x1,   bool,   None, ""],
-            ["sg_thrs",              0,  0xFFF, int,    None, ""]
+            ["sgthrs",              0,  0xFFF, int,    None, ""]
         ]
-        super().__init__(0x74, "SG_THRS", tmc_com, reg_map)
+        super().__init__(0x74, "SGTHRS", tmc_com, reg_map)
 
 
 class SgResult(TmcReg):
@@ -332,9 +332,9 @@ class SgResult(TmcReg):
         """constructor"""
 
         reg_map = [
-            ["sg_result",            0,  0xFFFFF, int, None, ""]
+            ["sgresult",            0,  0xFFFFF, int, None, ""]
         ]
-        super().__init__(0x75, "SG_RESULT", tmc_com, reg_map)
+        super().__init__(0x75, "SGRESULT", tmc_com, reg_map)
 
 
 class SgInd(TmcReg):

--- a/src/tmc_driver/reg/_tmc_reg.py
+++ b/src/tmc_driver/reg/_tmc_reg.py
@@ -57,9 +57,9 @@ class TmcReg():
         self._data_int = data
 
         for reg in self._reg_map:
-            name, pos, mask, _, _, _ = reg
+            name, pos, mask, reg_class, _, _ = reg
             value = data >> pos & mask
-            setattr(self, name, reg[3](value))
+            setattr(self, name, reg_class(value))
 
 
     def serialise(self) -> int:

--- a/src/tmc_driver/tmc_2209.py
+++ b/src/tmc_driver/tmc_2209.py
@@ -10,16 +10,13 @@
 import statistics
 import types
 from .tmc_220x import *
+from ._tmc_stallguard import StallGuard
 from ._tmc_gpio_board import GpioPUD
 from .reg._tmc2209_reg import *
 
 
-class Tmc2209(Tmc220x):
+class Tmc2209(Tmc220x, StallGuard):
     """Tmc2209"""
-
-    _pin_stallguard:int = None
-    _sg_callback:types.FunctionType = None
-    _sg_threshold:int = 100             # threshold for stallguard
 
 
 
@@ -78,6 +75,7 @@ class Tmc2209(Tmc220x):
         self.tmc_logger.log("TMC2209 Init finished", Loglevel.INFO)
 
 
+
     def __del__(self):
         """destructor"""
         if self._deinit_finished is False:
@@ -89,49 +87,8 @@ class Tmc2209(Tmc220x):
 
 
 
-    def set_stallguard_callback(self, pin_stallguard, threshold, callback,
-                                min_speed = 100):
-        """set a function to call back, when the driver detects a stall
-        via stallguard
-        high value on the diag pin can also mean a driver error
-
-        Args:
-            pin_stallguard (int): pin needs to be connected to DIAG
-            threshold (int): value for SGTHRS
-            callback (func): will be called on StallGuard trigger
-            min_speed (int): min speed [steps/s] for StallGuard (Default value = 100)
-        """
-        self.tmc_logger.log(f"setup stallguard callback on GPIO {pin_stallguard}", Loglevel.INFO)
-        self.tmc_logger.log(f"StallGuard Threshold: {threshold} | minimum Speed: {min_speed}", Loglevel.INFO)
-
-        self._set_stallguard_threshold(threshold)
-        self._set_coolstep_threshold(tmc_math.steps_to_tstep(min_speed, self.get_microstepping_resolution()))
-        self._sg_callback = callback
-        self._pin_stallguard = pin_stallguard
-
-        tmc_gpio.gpio_setup(self._pin_stallguard, GpioMode.IN, pull_up_down=GpioPUD.PUD_DOWN)
-        # first remove existing events
-        tmc_gpio.gpio_remove_event_detect(self._pin_stallguard)
-        tmc_gpio.gpio_add_event_detect(self._pin_stallguard, self.stallguard_callback)
-
-
-
-    def stallguard_callback(self, gpio_pin):
-        """the callback function for StallGuard.
-        only checks whether the duration of the current movement is longer than
-        _sg_delay and then calls the actual callback
-
-        Args:
-            gpio_pin (int): pin number of the interrupt pin
-        """
-        del gpio_pin
-        if self._sg_callback is None:
-            self.tmc_logger.log("StallGuard callback is None", Loglevel.DEBUG)
-            return
-        self._sg_callback()
-
-
-
+# Tmc2209 methods
+# ----------------------------
     def do_homing(self, diag_pin, revolutions = 10, threshold = None, speed_rpm = None) -> bool:
         """homes the motor in the given direction using stallguard.
         this method is using vactual to move the motor and an interrupt on the DIAG pin
@@ -197,7 +154,7 @@ class Tmc2209(Tmc220x):
         if not isinstance(self.tmc_mc, TmcMotionControlStepDir):
             self.tmc_logger.log("do_homing2 only works with STEP/DIR Control", Loglevel.ERROR)
             return
-        sg_results = []
+        sgresults = []
 
         if threshold is not None:
             self._sg_threshold = threshold
@@ -231,88 +188,29 @@ class Tmc2209(Tmc220x):
             if self.tmc_mc.run_speed(): #returns true, when a step is made
                 step_counter += 1
                 self.tmc_mc.compute_new_speed()
-                sg_result = self.get_stallguard_result()
-                sg_results.append(sg_result)
-                if len(sg_results)>20:
-                    sg_result_average = statistics.mean(sg_results[-6:])
-                    if sg_result_average < self._sg_threshold:
+                sgresult = self.get_stallguard_result()
+                sgresults.append(sgresult)
+                if len(sgresults)>20:
+                    sgresult_average = statistics.mean(sgresults[-6:])
+                    if sgresult_average < self._sg_threshold:
                         break
 
         if step_counter<self.tmc_mc.steps_per_rev:
             self.tmc_logger.log("homing successful",Loglevel.INFO)
             self.tmc_logger.log(f"Stepcounter: {step_counter}",Loglevel.DEBUG)
-            self.tmc_logger.log(str(sg_results),Loglevel.DEBUG)
+            self.tmc_logger.log(str(sgresults),Loglevel.DEBUG)
             self.tmc_mc.current_pos = 0
         else:
             self.tmc_logger.log("homing failed", Loglevel.INFO)
             self.tmc_logger.log(f"Stepcounter: {step_counter}", Loglevel.DEBUG)
-            self.tmc_logger.log(str(sg_results),Loglevel.DEBUG)
+            self.tmc_logger.log(str(sgresults),Loglevel.DEBUG)
 
         self.tmc_logger.log("---", Loglevel.INFO)
 
 
 
-    def get_stallguard_result(self):
-        """return the current stallguard result
-        its will be calculated with every fullstep
-        higher values means a lower motor load
-
-        Returns:
-            sg_result (int): StallGuard Result
-        """
-        self.sgresult.read()
-        return self.sgresult.sgresult
-
-
-
-    def _set_stallguard_threshold(self, threshold):
-        """sets the register bit "SGTHRS" to to a given value
-        this is needed for the stallguard interrupt callback
-        SG_RESULT becomes compared to the double of this threshold.
-        SG_RESULT ≤ SGTHRS*2
-
-        Args:
-            threshold (int): value for SGTHRS
-        """
-        self.sgthrs.modify("sgthrs", threshold)
-
-
-
-    def _set_coolstep_threshold(self, threshold):
-        """This  is  the  lower  threshold  velocity  for  switching
-        on  smart energy CoolStep and StallGuard to DIAG output. (unsigned)
-
-        Args:
-            threshold (int): threshold velocity for coolstep
-        """
-        self.tcoolthrs.modify("tcoolthrs", threshold)
-
-
-
-    def enable_coolstep(self, semin_sg:int = 150, semax_sg:int = 200, seup:int = 1, sedn:int = 3, min_speed:int = 100):
-        """enables coolstep and sets the parameters for coolstep
-        The values for semin etc. can be tested with the test_stallguard_threshold function
-
-        Args:
-            semin_sg (int): lower threshold. Current will be increased if SG_Result goes below this
-            semax_sg (int): upper threshold. Current will be decreased if SG_Result goes above this
-            seup (int): current increment step
-            sedn (int): number of SG_Result readings for each current decrement
-        """
-        semax_sg = semax_sg - semin_sg
-
-        self.coolconf.read()
-        self.coolconf.semin = round(max(0, min(semin_sg/32, 15)))
-        self.coolconf.semax = round(max(0, min(semax_sg/32, 15)))
-        self.coolconf.seimin = 1        # scale down to until 1/4 of IRun (7 - 31)
-        self.coolconf.seup = seup
-        self.coolconf.sedn = sedn
-        self.coolconf.write_check()
-
-        self._set_coolstep_threshold(tmc_math.steps_to_tstep(min_speed, self.get_microstepping_resolution()))
-
-
-
+# Test methods
+# ----------------------------
     def test_stallguard_threshold(self, steps):
         """test method for tuning stallguard threshold
 
@@ -322,7 +220,6 @@ class Tmc2209(Tmc220x):
         Args:
             steps (int):
         """
-
         self.tmc_logger.log("---", Loglevel.INFO)
         self.tmc_logger.log("test_stallguard_threshold", Loglevel.INFO)
 
@@ -339,12 +236,8 @@ class Tmc2209(Tmc220x):
             stallguard_result = self.get_stallguard_result()
             self.drvstatus.read()
             cs_actual = self.drvstatus.cs_actual
-            # stallguard_result = self.get_stallguard_result()
 
             self.tmc_logger.log(f"{self.tmc_mc.movement_phase} | {stallguard_result} | {cs_actual}",
-                        Loglevel.INFO)
-
-            self.tmc_logger.log(f"{self.tmc_mc.movement_phase} | {stallguard_result}",
                         Loglevel.INFO)
 
             if (self.tmc_mc.movement_phase == MovementPhase.ACCELERATING and

--- a/src/tmc_driver/tmc_220x.py
+++ b/src/tmc_driver/tmc_220x.py
@@ -45,6 +45,7 @@ class Tmc220x(TmcStepperDriver):
     tmc_com:TmcComUart = None
 
 
+
 # Constructor/Destructor
 # ----------------------------
     def __init__(self,
@@ -149,6 +150,7 @@ class Tmc220x(TmcStepperDriver):
     def set_deinitialize_true(self):
         """set deinitialize to true"""
         self._deinit_finished = True
+
 
 
 # Tmc220x methods
@@ -622,6 +624,8 @@ class Tmc220x(TmcStepperDriver):
 
 
 
+# Test methods
+# ----------------------------
     def test_pin(self, pin, ioin_reg_bp):
         """tests one pin
 


### PR DESCRIPTION
- moved StallGuard code into own mixin class
- fixed StallGuard on TMC2240 (diag0_pushpull and diag0_stall needed to be activated)
- renamed sgresult and sgthrs reg values in order to have them consistend between drivers